### PR TITLE
fix log monitor config file and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN mkdir C:\LogMonitor
 RUN copy C:\app\LogMonitor.exe C:\LogMonitor
 RUN copy C:\app\LogMonitorConfig.json C:\LogMonitor
 
-SHELL ["C:/LogMonitor/LogMonitor.exe", "cmd", "/S", "/C"]
-
 
 # Install the service
 RUN powershell -Command \
@@ -20,7 +18,8 @@ RUN powershell -Command \
         Start-Service -Name "Service1"
 
 
+# SHELL ["C:/LogMonitor/LogMonitor.exe", "cmd", "/S", "/C"]
 # Define the entry point for the container
- ENTRYPOINT ["powershell", "-Command", "Start-Service -Name Service1; Wait-Event -Timeout 2147483647"]
+ENTRYPOINT ["C:/LogMonitor/LogMonitor.exe", "powershell", "-Command", "Start-Service -Name Service1; Wait-Event -Timeout 2147483647"]
 
  # CMD ["cmd", "/c", "sc create Service1 binPath= \"C:\\app\\WindowsService1.exe\" DisplayName= \"Service1\" start= auto && sc start Service1 && timeout /t -1 /nobreak"]

--- a/LogMonitorConfig.json
+++ b/LogMonitorConfig.json
@@ -1,35 +1,29 @@
 ﻿{
-    "LogConfig": {
-        "sources": [
+  "LogConfig": {
+    "sources": [
+      {
+        "type": "EventLog",
+        "startAtOldestRecord": true,
+        "eventFormatMultiLine": true,
+        "channels": [
           {
-            "type": "EventLog",
-            "startAtOldestRecord": true,
-            "eventFormatMultiLine": true,
-            "channels": [
-              {
-                "name": "system",
-                "level": "Information"
-              },
-              {
-                "name": "application",
-                "level": "Error"
-              }
-            ]
+            "name": "system",
+            "level": "Information"
           },
           {
-            "LogConfig": {
-              "sources": [
-                {
-                  "type": "File",
-                  "directory": "c:\\app\\",
-                  "filter": "*.txt",
-                  "includeSubdirectories": false,
-                  "includeFileNames": false,
-                  "waitInSeconds": 3
-                }
-              ]
-            }
+            "name": "application",
+            "level": "Error"
           }
         ]
+      },
+      {
+        "type": "File",
+        "directory": "c:\\app\\",
+        "filter": "*.txt",
+        "includeSubdirectories": false,
+        "includeFileNames": false,
+        "waitInSeconds": 3
+      }
+    ]
   }
 }

--- a/bin/Release/LogMonitorConfig.json
+++ b/bin/Release/LogMonitorConfig.json
@@ -1,35 +1,29 @@
 ﻿{
-    "LogConfig": {
-        "sources": [
+  "LogConfig": {
+    "sources": [
+      {
+        "type": "EventLog",
+        "startAtOldestRecord": true,
+        "eventFormatMultiLine": true,
+        "channels": [
           {
-            "type": "EventLog",
-            "startAtOldestRecord": true,
-            "eventFormatMultiLine": true,
-            "channels": [
-              {
-                "name": "system",
-                "level": "Information"
-              },
-              {
-                "name": "application",
-                "level": "Error"
-              }
-            ]
+            "name": "system",
+            "level": "Information"
           },
           {
-            "LogConfig": {
-              "sources": [
-                {
-                  "type": "File",
-                  "directory": "c:\\app\\",
-                  "filter": "*.txt",
-                  "includeSubdirectories": false,
-                  "includeFileNames": false,
-                  "waitInSeconds": 3
-                }
-              ]
-            }
+            "name": "application",
+            "level": "Error"
           }
         ]
+      },
+      {
+        "type": "File",
+        "directory": "c:\\app\\",
+        "filter": "*.txt",
+        "includeSubdirectories": false,
+        "includeFileNames": false,
+        "waitInSeconds": 3
+      }
+    ]
   }
 }


### PR DESCRIPTION
- The File Monitor config was invalid causing file monitor startup failure
- In the Dockerfile, Log Monitor was being utilized to install the service which is a build time task, Log Monitor requires to run through the lifetime of the container and is better used as the Container Entry point. 
- For Console output, we need to investigate how we can capture a services stdout logs. 
